### PR TITLE
only displaying fields who aren't at capacity

### DIFF
--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+
 using Trestlebridge.Interfaces;
 using Trestlebridge.Models;
 using Trestlebridge.Models.Animals;
@@ -8,20 +9,31 @@ namespace Trestlebridge.Actions
 {
     public class ChooseGrazingField
     {
-        public static void CollectInput(Farm farm, IGrazing animal)
+        public static void CollectInput (Farm farm, IGrazing animal)
         {
-            Utils.Clear();
+            Utils.Clear ();
+
             for (int i = 0; i < farm.GrazingFields.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. {farm.GrazingFields[i].ToString()} Max Capacity: {farm.GrazingFields[i].Capacity}");
+
+                if (farm.GrazingFields[i].animalCount != farm.GrazingFields[i].Capacity)
+                {
+
+                    Console.WriteLine ($"{i + 1}. {farm.GrazingFields[i].ToString()} Max Capacity: {farm.GrazingFields[i].Capacity}");
+                }
+
             }
+
             //
-            Console.WriteLine();
+            Console.WriteLine ();
             // How can I output the type of animal chosen here?
-            Console.WriteLine($"Place the animal where?");
-            Console.Write("> ");
-            int choice = Int32.Parse(Console.ReadLine()) - 1;
-            farm.GrazingFields[choice].AddResource(animal);
+
+            Console.WriteLine ($"Place the animal where?");
+            Console.Write ("> ");
+            int choice = Int32.Parse (Console.ReadLine ()) - 1;
+
+            farm.GrazingFields[choice].AddResource (animal);
+
             /*
                 Couldn't get this to work. Can you?
                 Stretch goal. Only if the app is fully functional.

--- a/src/Models/Facilities/GrazingField.cs
+++ b/src/Models/Facilities/GrazingField.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+
 using Trestlebridge;
 using Trestlebridge.Actions;
 using Trestlebridge.Interfaces;
@@ -10,8 +11,8 @@ namespace Trestlebridge.Models.Facilities
 {
     public class GrazingField : IFacility<IGrazing>
     {
-        private int _capacity = 3;
-        private Guid _id = Guid.NewGuid();
+        private int _capacity = 1;
+        private Guid _id = Guid.NewGuid ();
         public double animalCount
         {
             get
@@ -19,7 +20,7 @@ namespace Trestlebridge.Models.Facilities
                 return _animals.Count;
             }
         }
-        private List<IGrazing> _animals = new List<IGrazing>();
+        private List<IGrazing> _animals = new List<IGrazing> ();
         public double Capacity
         {
             get
@@ -27,37 +28,37 @@ namespace Trestlebridge.Models.Facilities
                 return _capacity;
             }
         }
-        public void AddResource(IGrazing animal)
+        public void AddResource (IGrazing animal)
         {
             // while (true)
             // {
             if (_animals.Count < Capacity)
             {
-                _animals.Add(animal);
+                _animals.Add (animal);
                 return;
             }
             //
             else
             {
-                Console.WriteLine("Too many animals in there!");
-                Console.WriteLine("Hit ENTER to continue.");
-                Console.ReadLine();
+                Console.WriteLine ("Too many animals in there!");
+                Console.WriteLine ("Hit ENTER to continue.");
+                Console.ReadLine ();
                 return;
             }
             //}
         }
-        public void AddResource(List<IGrazing> animals)
+        public void AddResource (List<IGrazing> animals)
         {
             // TODO: implement this...
-            throw new NotImplementedException();
+            throw new NotImplementedException ();
         }
-        public override string ToString()
+        public override string ToString ()
         {
-            StringBuilder output = new StringBuilder();
+            StringBuilder output = new StringBuilder ();
             string shortId = $"{this._id.ToString().Substring(this._id.ToString().Length - 6)}";
-            output.Append($"Grazing field {shortId} has {this._animals.Count} animals\n");
-            this._animals.ForEach(a => output.Append($"   {a}\n"));
-            return output.ToString();
+            output.Append ($"Grazing field {shortId} has {this._animals.Count} animals\n");
+            this._animals.ForEach (a => output.Append ($"   {a}\n"));
+            return output.ToString ();
         }
     }
 }


### PR DESCRIPTION
a user should be able to purchase an animal and assign it to a field. 

the program will only display `grazing fields` whose capacity hasn't been met yet.

still working on figuring out how a user can return home if there are no available fields. 